### PR TITLE
chore: #22 - Update import paths for shared modules

### DIFF
--- a/components/sections/navigation-component.vue
+++ b/components/sections/navigation-component.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import type { Category } from '~/functions/src/shared';
-import type { Site } from '~/functions/src/shared';
+import type { Category, Site } from '~/shared';
 
 const { locale } = useI18n();
 const localePath = useLocalePath();

--- a/components/tools/markdown-component.vue
+++ b/components/tools/markdown-component.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { MDCParserResult } from '@nuxtjs/mdc';
-import type { I18n } from '~/functions/src/shared';
 
 const { locale } = useI18n();
 const { $translate } = useNuxtApp() as any;

--- a/composables/useContent.ts
+++ b/composables/useContent.ts
@@ -1,4 +1,4 @@
-import type { Category, Content, locales, Site } from "~/functions/src/shared";
+import type { Category, Content, locales, Site } from "~/shared";
 
 
 const fetchDomain = async (domain: string): Promise<Site> => {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -31,5 +31,9 @@ export default defineNuxtConfig({
     "@nuxtjs/i18n",
     "@nuxtjs/mdc",
     "@nuxt/image"
-  ]
+  ],
+
+  alias: {
+    '~/shared': '/functions/src/shared'
+  }
 })

--- a/pages/[category-slug]/[article-slug].vue
+++ b/pages/[category-slug]/[article-slug].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Content } from '~/functions/src/shared';
+import type { Content } from '~/shared';
 
 const { locale } = useI18n();
 const { params } = useRoute();

--- a/pages/categories/[category-slug].vue
+++ b/pages/categories/[category-slug].vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type { Category } from '~/functions/src/shared';
-import type { Content } from '~/functions/src/shared';
+import type { Category } from '~/shared';
+import type { Content } from '~/shared';
 
 const { locale } = useI18n();
 const localePath = useLocalePath();

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Site } from '~/functions/src/shared';
+import type { Site } from '~/shared';
 const { locale } = useI18n();
 const { $domain, $translate } = useNuxtApp() as any;
 const { fetchDomain } = useContent();

--- a/server/api/categories/[categorySlug].ts
+++ b/server/api/categories/[categorySlug].ts
@@ -1,7 +1,6 @@
 // /server/api/getData.js
-import { categoryFactory, getSiteByDomain } from '~/functions/src/shared';
+import { categoryFactory, getSiteByDomain, Category } from '~/shared';
 import { db } from '../../firebase';
-import { Category } from '~/functions/src/shared';
 import { ApiResponse, DomainQuery, ErrorResponse, LocaleQuery } from '~/server/types';
 
 

--- a/server/api/categories/index.ts
+++ b/server/api/categories/index.ts
@@ -1,7 +1,7 @@
 // /server/api/getData.js
 import { ApiResponse, DomainQuery, ErrorResponse } from '~/server/types';
 import { db } from '../../firebase';
-import { Category, categoryFactory, getSiteByDomain } from '~/functions/src/shared';
+import { Category, categoryFactory, getSiteByDomain } from '~/shared';
 
 export default defineEventHandler(async (event) => {
     const { name } = getQuery(event) as DomainQuery;

--- a/server/api/contents/[contentSlug].ts
+++ b/server/api/contents/[contentSlug].ts
@@ -1,7 +1,7 @@
 // /server/api/getData.js
-import { db } from '../../firebase';
-import { Content, getSiteByDomain } from '~/functions/src/shared';
 import { ApiResponse, CategoryQuery, DomainQuery, ErrorResponse } from '~/server/types';
+import { Content, getSiteByDomain } from '~/shared';
+import { db } from '../../firebase';
 
 
 export default defineEventHandler(async (event) => {

--- a/server/api/contents/index.ts
+++ b/server/api/contents/index.ts
@@ -1,8 +1,7 @@
 // /server/api/getData.js
-import { db } from '../../firebase';
-import { Content, getSiteByDomain } from '~/functions/src/shared';
 import { ApiResponse, CategoryQuery, DomainQuery, ErrorResponse } from '~/server/types';
-
+import { Content, getSiteByDomain } from '~/shared';
+import { db } from '../../firebase';
 
 export default defineEventHandler(async (event) => {
     const { name, categorySlug } = getQuery(event) as DomainQuery & CategoryQuery;

--- a/server/api/domains/index.ts
+++ b/server/api/domains/index.ts
@@ -1,5 +1,5 @@
 // /server/api/getData.js
-import { Domain } from '~/functions/src/shared';
+import { Domain } from '~/shared';
 import { db } from '../../firebase';
 import { ApiResponse, DomainQuery, ErrorResponse } from '~/server/types';
 

--- a/server/api/services/domain.ts
+++ b/server/api/services/domain.ts
@@ -1,8 +1,7 @@
-import { categoryFactory, siteFactory } from '~/functions/src/shared';
-import { db } from '../../firebase';
-import { MetaSeo } from '~/functions/src/shared';
-import { createSite } from '~/functions/src/shared';
+// /server/api/getData.js
 import { DomainQuery } from '~/server/types';
+import { MetaSeo, categoryFactory, createSite, siteFactory } from '~/shared';
+import { db } from '../../firebase';
 
 export default defineEventHandler(async (event) => {
     const { name } = getQuery(event) as DomainQuery;

--- a/server/api/services/sites/index.ts
+++ b/server/api/services/sites/index.ts
@@ -1,4 +1,4 @@
-import { initSite, Config } from "~/functions/src/shared";
+import { initSite, Config } from "~/shared";
 import { db } from "../../../firebase";
 
 

--- a/server/api/sites/index.ts
+++ b/server/api/sites/index.ts
@@ -1,7 +1,7 @@
 // /server/api/getData.js
+import { ApiResponse, DomainQuery, ErrorResponse } from '~/server/types';
+import { getSiteByDomain, Site, siteFactory } from '~/shared';
 import { db } from '../../firebase';
-import { getSiteByDomain, Site, siteFactory, } from '~/functions/src/shared';
-import { DomainQuery, ApiResponse, ErrorResponse } from '~/server/types';
 
 export default defineEventHandler(async (event) => {
     const { name } = getQuery(event) as DomainQuery;

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,4 +1,4 @@
-import { locales } from "~/functions/src/shared";
+import { locales } from "~/shared";
 
 export type DomainQuery = {
     name: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,18 @@
 {
   // https://nuxt.com/docs/guide/concepts/typescript
   "extends": "./.nuxt/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": [
+        "./*"
+      ],
+      "@/*": [
+        "./*"
+      ],
+      "~/shared": [
+        "./functions/src/shared"
+      ]
+    },
+  }
 }


### PR DESCRIPTION
This commit updates the import paths for shared modules in multiple files. The import statements have been changed from "~/functions/src/shared" to "~/shared". This change improves the organization and structure of the codebase.